### PR TITLE
Publish a transpiled version to NPM

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,7 +3,8 @@
         "@babel/plugin-proposal-export-default-from",
         "@babel/plugin-proposal-export-namespace-from",
         "@babel/plugin-proposal-class-properties",
-        "@babel/plugin-proposal-optional-chaining"
+        "@babel/plugin-proposal-optional-chaining",
+        "babel-plugin-styled-components"
     ],
     "presets": [
         [
@@ -11,12 +12,7 @@
             {
                 "corejs": 3,
                 "useBuiltIns": "usage",
-                "targets": [
-                    ">0.5%",
-                    "last 2 versions",
-                    "node >= 10",
-                    "not dead"
-                ]
+                "targets": [">0.5%", "last 2 versions", "not dead"]
             }
         ],
         "@babel/preset-react"

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.lock
 /cypress/screenshots
 /cypress/videos
+/dist
 /public
 
 # Created by https://www.gitignore.io/api/node,linux,macos,windows,intellij,webstorm,reactnative

--- a/.npmignore
+++ b/.npmignore
@@ -2,7 +2,7 @@
 .babelrc
 .eslintrc
 .prettierrc
-src/**/src/*.md
+src
 *.stories.js
 *.test.js
 

--- a/.npmignore
+++ b/.npmignore
@@ -2,7 +2,6 @@
 .babelrc
 .eslintrc
 .prettierrc
-src
 *.stories.js
 *.test.js
 

--- a/components.js
+++ b/components.js
@@ -6,7 +6,7 @@ import {
     ErrorBoundary,
     FeedbackCard,
     FormField
-} from './components';
+} from './dist/components';
 
 export {
     DataTable,

--- a/elements.js
+++ b/elements.js
@@ -27,7 +27,7 @@ import {
     Text,
     TextField,
     Undraw
-} from './elements';
+} from './dist/elements';
 
 export {
     Button,

--- a/package.json
+++ b/package.json
@@ -73,5 +73,5 @@
         "build": "build-storybook -c .storybook -o public",
         "test": "jest"
     },
-    "version": "0.6.31"
+    "version": "0.7.0"
 }

--- a/package.json
+++ b/package.json
@@ -76,5 +76,5 @@
         "postpublish": "mv ../src /",
         "test": "jest"
     },
-    "version": "0.7.0"
+    "version": "0.7.1"
 }

--- a/package.json
+++ b/package.json
@@ -71,6 +71,9 @@
         "storybook": "start-storybook -p 6006",
         "build-storybook": "build-storybook",
         "build": "build-storybook -c .storybook -o public",
+        "prepublish": "babel src --out-dir dist --ignore \"src/**/*.stories.js\"",
+        "prepublishOnly": "mv src/ ../",
+        "postpublish": "mv ../src /",
         "test": "jest"
     },
     "version": "0.7.0"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     },
     "author": "Andrew Slattery <andrew@hln.com>",
     "license": "MIT",
-    "main": "src/index.js",
+    "main": "dist/index.js",
     "devDependencies": {
         "@babel/cli": "^7.8.3",
         "@babel/core": "^7.8.3",
@@ -19,6 +19,8 @@
         "@babel/plugin-proposal-export-default-from": "^7.8.3",
         "@babel/plugin-proposal-export-namespace-from": "^7.8.3",
         "@babel/plugin-proposal-optional-chaining": "^7.8.3",
+        "@babel/preset-env": "^7.8.4",
+        "@babel/preset-react": "^7.8.3",
         "@storybook/addon-a11y": "^5.3.3",
         "@storybook/addon-actions": "^5.3.3",
         "@storybook/addon-docs": "^5.3.3",
@@ -32,9 +34,9 @@
         "@storybook/theming": "^5.3.3",
         "babel-eslint": "^10.0.2",
         "babel-jest": "^24.8.0",
-        "babel-loader": "^8.0.6",
+        "babel-plugin-styled-components": "^1.10.7",
         "chance": "^1.1.4",
-        "core-js": "3.6.4",
+        "core-js": "3",
         "enzyme": "^3.10.0",
         "enzyme-adapter-react-16": "^1.14.0",
         "eslint": "^6.8.0",
@@ -64,6 +66,7 @@
         "react-transition-group": "^4.3.0"
     },
     "peerDependencies": {
+        "react": ">= 16.9",
         "styled-components": ">= 5"
     },
     "scripts": {
@@ -71,7 +74,8 @@
         "storybook": "start-storybook -p 6006",
         "build-storybook": "build-storybook",
         "build": "build-storybook -c .storybook -o public",
-        "test": "jest"
+        "test": "jest",
+        "transpile-for-dist": "babel src --out-dir dist --ignore \"src/**/*.stories.js\""
     },
-    "version": "0.6.31"
+    "version": "0.7.0"
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     },
     "author": "Andrew Slattery <andrew@hln.com>",
     "license": "MIT",
-    "main": "dist/index.js",
+    "main": "src/index.js",
     "devDependencies": {
         "@babel/cli": "^7.8.3",
         "@babel/core": "^7.8.3",
@@ -19,8 +19,6 @@
         "@babel/plugin-proposal-export-default-from": "^7.8.3",
         "@babel/plugin-proposal-export-namespace-from": "^7.8.3",
         "@babel/plugin-proposal-optional-chaining": "^7.8.3",
-        "@babel/preset-env": "^7.8.4",
-        "@babel/preset-react": "^7.8.3",
         "@storybook/addon-a11y": "^5.3.3",
         "@storybook/addon-actions": "^5.3.3",
         "@storybook/addon-docs": "^5.3.3",
@@ -34,9 +32,9 @@
         "@storybook/theming": "^5.3.3",
         "babel-eslint": "^10.0.2",
         "babel-jest": "^24.8.0",
-        "babel-plugin-styled-components": "^1.10.7",
+        "babel-loader": "^8.0.6",
         "chance": "^1.1.4",
-        "core-js": "3",
+        "core-js": "3.6.4",
         "enzyme": "^3.10.0",
         "enzyme-adapter-react-16": "^1.14.0",
         "eslint": "^6.8.0",
@@ -66,7 +64,6 @@
         "react-transition-group": "^4.3.0"
     },
     "peerDependencies": {
-        "react": ">= 16.9",
         "styled-components": ">= 5"
     },
     "scripts": {
@@ -74,8 +71,7 @@
         "storybook": "start-storybook -p 6006",
         "build-storybook": "build-storybook",
         "build": "build-storybook -c .storybook -o public",
-        "test": "jest",
-        "transpile-for-dist": "babel src --out-dir dist --ignore \"src/**/*.stories.js\""
+        "test": "jest"
     },
-    "version": "0.7.0"
+    "version": "0.6.31"
 }

--- a/themes.js
+++ b/themes.js
@@ -1,3 +1,3 @@
-import { defaultTheme } from './themes';
+import { defaultTheme } from './dist/themes';
 
 export { defaultTheme };


### PR DESCRIPTION
Work around the hacky solutions we've implemented by transpiling the `src/` directory, less stories, and then publishing that as the final package.